### PR TITLE
added docker-compose and db config for prod and dev databases

### DIFF
--- a/config/db.ts
+++ b/config/db.ts
@@ -3,3 +3,17 @@ import mongoose from 'mongoose';
 export const connectToDatabase = (mongodbURL: string) => {
   return mongoose.connect(mongodbURL);
 };
+
+interface DbConfig {
+  databaseUrl: string;
+}
+
+const getDbConfig = (): DbConfig => {
+  return {
+    databaseUrl: process.env.NODE_ENV === 'production'
+      ? process.env.MONGODB_URL || ''
+      : process.env.DEV_MONGODB_URL || 'mongodb://localhost:27017/ws-db',
+  };
+};
+
+export default getDbConfig;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  ws-db:
+    image: mongo:latest
+    container_name: ws-db
+    ports:
+      - "27017:27017"

--- a/models/uploadModel.ts
+++ b/models/uploadModel.ts
@@ -1,0 +1,17 @@
+import { Schema, model } from "mongoose";
+
+interface IUpload {
+  a: string;
+  b: number;
+  c: string;
+}
+
+const uploadSchema = new Schema(
+  {
+    a: { type: String, required: true },
+    b: { type: Number, required: true },
+    c: { type: String, required: true }
+  }
+)
+
+export const Upload = model<IUpload>('new', uploadSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/node": "^20.8.10",
         "cors": "^2.8.5",
+        "csvtojson": "^2.0.10",
         "express": "^4.18.2",
         "mongoose": "^8.0.0"
       },
@@ -21,6 +22,9 @@
         "nodemon": "^3.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18.18.0 <19.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -299,6 +303,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -468,6 +477,22 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -866,6 +891,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -873,6 +903,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1418,6 +1453,17 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "start": "node ./dist/server/index.js",
+    "start": "set NODE_ENV=production && node ./dist/server/index.js",
     "dev": "nodemon server/index.ts",
-    "build": "npm install && tsc"
+    "build": "npm install && tsc",
+    "start:dev": "nodemon server/index.ts",
+    "start:prod": "set NODE_ENV=production && nodemon server/index.ts"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +24,7 @@
   "dependencies": {
     "@types/node": "^20.8.10",
     "cors": "^2.8.5",
+    "csvtojson": "^2.0.10",
     "express": "^4.18.2",
     "mongoose": "^8.0.0"
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,13 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import { configureApp } from '../config/app';
-import { connectToDatabase } from '../config/db';
+import getDbConfig, { connectToDatabase } from '../config/db';
 
 dotenv.config();
-
 const app = express();
-const mongodbURL: string = process.env.MONGODB_URL || '';
+
+const dbConfig = getDbConfig();
+const mongodbURL = dbConfig.databaseUrl;
 const PORT = process.env.PORT || 3000
 
 configureApp(app)
@@ -16,6 +17,7 @@ connectToDatabase(mongodbURL)
     console.log('App connected to database');
     app.listen(PORT, () => {
       console.log(`App is listening to port: ${PORT}`);
+      console.log(`App running on ${process.env.NODE_ENV}`);
     });
   })
   .catch((error) => {


### PR DESCRIPTION
# What this PR does:

- creates a docker container through docker-compose file
- created files for dbconfig to switch through dev and production databases

# How to test:

- run `docker-compose up -d`
- test `npm run dev` and `npm start`